### PR TITLE
Potential fix for code scanning alert no. 99: Full server-side request forgery

### DIFF
--- a/buggy_python_code.py
+++ b/buggy_python_code.py
@@ -27,7 +27,21 @@ def print_nametag(format_string, person):
 def fetch_website(urllib_version, url):
     if urllib_version != "3":
         raise ValueError("zle")
-        
+    
+    # Whitelist of allowed domains
+    allowed_domains = ["example.com", "google.com"]
+    
+    # Validate and parse the URL
+    from urllib.parse import urlparse
+    parsed_url = urlparse(url)
+    if not parsed_url.scheme or not parsed_url.netloc:
+        raise ValueError("Invalid URL format")
+    
+    # Check if the domain is in the whitelist
+    domain = parsed_url.netloc.split(':')[0]  # Exclude port if present
+    if domain not in allowed_domains:
+        raise ValueError("Domain not allowed")
+    
     try: 
         with urllib.request.urlopen(url) as response:
             content = response.read()


### PR DESCRIPTION
Potential fix for [https://github.com/Pyro-dev601/PV080_buggy_code/security/code-scanning/99](https://github.com/Pyro-dev601/PV080_buggy_code/security/code-scanning/99)

To fix the SSRF vulnerability, we need to ensure that user-provided URLs are validated and restricted to a safe set of domains or IP addresses. The best approach is to maintain a whitelist of allowed domains and verify that the user-provided URL resolves to one of these domains. Additionally, we can use a library like `validators` to ensure the URL is well-formed.

Steps to fix:
1. Add a whitelist of allowed domains (e.g., `["example.com", "google.com"]`).
2. Parse the user-provided URL and extract its domain.
3. Check if the domain is in the whitelist. If not, reject the request.
4. Use a library like `validators` to validate the URL format.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
